### PR TITLE
Remove usage of AXI_ERROR_RESP_G

### DIFF
--- a/firmware/common/PrbsTester/rtl/Hardware.vhd
+++ b/firmware/common/PrbsTester/rtl/Hardware.vhd
@@ -2,7 +2,7 @@
 -- File       : Hardware.vhd
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2017-10-26
--- Last update: 2018-02-08
+-- Last update: 2018-02-12
 -------------------------------------------------------------------------------
 -- Description: Hardware File
 -------------------------------------------------------------------------------
@@ -34,7 +34,6 @@ entity Hardware is
    generic (
       TPD_G            : time             := 1 ns;
       NUM_VC_G         : positive         := 4;
-      AXI_ERROR_RESP_G : slv(1 downto 0)  := AXI_RESP_DECERR_C;
       AXI_BASE_ADDR_G  : slv(31 downto 0) := x"0000_0000");
    port (
       -- AXI-Lite Interface
@@ -74,7 +73,6 @@ begin
    U_XBAR : entity work.AxiLiteCrossbar
       generic map (
          TPD_G              => TPD_G,
-         DEC_ERROR_RESP_G   => AXI_ERROR_RESP_G,
          NUM_SLAVE_SLOTS_G  => 1,
          NUM_MASTER_SLOTS_G => NUM_AXI_MASTERS_C,
          MASTERS_CONFIG_G   => AXI_CONFIG_C)
@@ -100,8 +98,7 @@ begin
             TPD_G            => TPD_G,
             LANE_G           => i,
             NUM_VC_G         => NUM_VC_G,
-            AXI_BASE_ADDR_G  => AXI_CONFIG_C(i).baseAddr,
-            AXI_ERROR_RESP_G => AXI_ERROR_RESP_G)
+            AXI_BASE_ADDR_G  => AXI_CONFIG_C(i).baseAddr)
          port map(
             -- DMA Interface
             dmaClk          => dmaClk,

--- a/firmware/common/PrbsTester/rtl/PrbsLane.vhd
+++ b/firmware/common/PrbsTester/rtl/PrbsLane.vhd
@@ -2,7 +2,7 @@
 -- File       : PrbsLane.vhd
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2017-10-26
--- Last update: 2018-02-09
+-- Last update: 2018-02-12
 -------------------------------------------------------------------------------
 -- Description: 
 -------------------------------------------------------------------------------
@@ -32,8 +32,7 @@ entity PrbsLane is
       TPD_G            : time             := 1 ns;
       LANE_G           : natural          := 0;
       NUM_VC_G         : positive         := 4;
-      AXI_BASE_ADDR_G  : slv(31 downto 0) := (others => '0');
-      AXI_ERROR_RESP_G : slv(1 downto 0)  := AXI_RESP_SLVERR_C);
+      AXI_BASE_ADDR_G  : slv(31 downto 0) := (others => '0'));
    port (
       -- DMA Interface (dmaClk domain)
       dmaClk          : in  sl;
@@ -93,7 +92,6 @@ begin
    U_XBAR : entity work.AxiLiteCrossbar
       generic map (
          TPD_G              => TPD_G,
-         DEC_ERROR_RESP_G   => AXI_ERROR_RESP_G,
          NUM_SLAVE_SLOTS_G  => 1,
          NUM_MASTER_SLOTS_G => NUM_AXI_MASTERS_C,
          MASTERS_CONFIG_G   => AXI_CONFIG_C)

--- a/firmware/common/pgp2b/core/PgpMiscCtrl.vhd
+++ b/firmware/common/pgp2b/core/PgpMiscCtrl.vhd
@@ -2,7 +2,7 @@
 -- File       : PgpMiscCtrl.vhd
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2017-10-04
--- Last update: 2018-02-08
+-- Last update: 2018-02-12
 -------------------------------------------------------------------------------
 -- Description: 
 -------------------------------------------------------------------------------
@@ -27,8 +27,7 @@ use work.AppPkg.all;
 
 entity PgpMiscCtrl is
    generic (
-      TPD_G            : time            := 1 ns;
-      AXI_ERROR_RESP_G : slv(1 downto 0) := AXI_RESP_DECERR_C);
+      TPD_G            : time            := 1 ns);
    port (
       -- Control/Status  (axilClk domain)
       config          : out ConfigType;
@@ -97,7 +96,7 @@ begin
       axiSlaveRegister(regCon, x"84", 0, v.rxUserRst);
 
       -- Closeout the transaction
-      axiSlaveDefault(regCon, v.axilWriteSlave, v.axilReadSlave, AXI_ERROR_RESP_G);
+      axiSlaveDefault(regCon, v.axilWriteSlave, v.axilReadSlave, AXI_RESP_DECERR_C);
 
       -- Synchronous Reset
       if (axilRst = '1') then

--- a/firmware/common/pgp2b/hardware/AdmPcieKu3/rtl/Hardware.vhd
+++ b/firmware/common/pgp2b/hardware/AdmPcieKu3/rtl/Hardware.vhd
@@ -2,7 +2,7 @@
 -- File       : Hardware.vhd
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2017-10-26
--- Last update: 2018-01-08
+-- Last update: 2018-02-12
 -------------------------------------------------------------------------------
 -- Description: Hardware File
 -------------------------------------------------------------------------------
@@ -33,7 +33,6 @@ use unisim.vcomponents.all;
 entity Hardware is
    generic (
       TPD_G            : time             := 1 ns;
-      AXI_ERROR_RESP_G : slv(1 downto 0)  := AXI_RESP_DECERR_C;
       AXI_BASE_ADDR_G  : slv(31 downto 0) := x"0000_0000");
    port (
       ------------------------      
@@ -83,7 +82,6 @@ begin
       generic map (
          TPD_G            => TPD_G,
          REFCLK_WIDTH_G   => 1,
-         AXI_ERROR_RESP_G => AXI_ERROR_RESP_G,
          AXI_BASE_ADDR_G  => AXI_BASE_ADDR_G)
       port map (
          -- QSFP[0] Ports

--- a/firmware/common/pgp2b/hardware/PgpCardG3/rtl/Hardware.vhd
+++ b/firmware/common/pgp2b/hardware/PgpCardG3/rtl/Hardware.vhd
@@ -2,7 +2,7 @@
 -- File       : Hardware.vhd
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2017-10-04
--- Last update: 2018-02-08
+-- Last update: 2018-02-12
 -------------------------------------------------------------------------------
 -- Description: 
 -------------------------------------------------------------------------------
@@ -27,7 +27,6 @@ use work.AxiStreamPkg.all;
 entity Hardware is
    generic (
       TPD_G            : time                 := 1 ns;
-      AXI_ERROR_RESP_G : slv(1 downto 0)      := AXI_RESP_DECERR_C;
       AXI_BASE_ADDR_G  : slv(31 downto 0)     := x"0080_0000");
    port (
       ------------------------      
@@ -66,7 +65,6 @@ begin
    U_Pgp : entity work.PgpLaneWrapper
       generic map (
          TPD_G            => TPD_G,
-         AXI_ERROR_RESP_G => AXI_ERROR_RESP_G,
          AXI_BASE_ADDR_G  => AXI_BASE_ADDR_G)
       port map (
          -- PGP GT Serial Ports

--- a/firmware/common/pgp2b/hardware/PgpCardG3/rtl/Pgp2bGtp7DrpWrapper.vhd
+++ b/firmware/common/pgp2b/hardware/PgpCardG3/rtl/Pgp2bGtp7DrpWrapper.vhd
@@ -2,7 +2,7 @@
 -- File       : Pgp2bGtp7DrpWrapper.vhd
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2013-06-29
--- Last update: 2017-10-20
+-- Last update: 2018-02-12
 -------------------------------------------------------------------------------
 -- Description: Gtp7 Variable Latency, multi-lane Module
 -------------------------------------------------------------------------------
@@ -34,7 +34,6 @@ entity Pgp2bGtp7DrpWrapper is
       VC_INTERLEAVE_G   : integer              := 0;  -- No interleave Frames
       PAYLOAD_CNT_TOP_G : integer              := 7;  -- Top bit for payload counter
       NUM_VC_EN_G       : integer range 1 to 4 := 4;
-      AXI_ERROR_RESP_G  : slv(1 downto 0)      := AXI_RESP_DECERR_C;
       TX_POLARITY_G     : sl                   := '0';
       RX_POLARITY_G     : sl                   := '0';
       TX_ENABLE_G       : boolean              := true;  -- Enable TX direction
@@ -430,7 +429,6 @@ begin
       U_AxiLiteToDrp : entity work.AxiLiteToDrp
          generic map (
             TPD_G            => TPD_G,
-            AXI_ERROR_RESP_G => AXI_ERROR_RESP_G,
             COMMON_CLK_G     => true,
             EN_ARBITRATION_G => true,
             TIMEOUT_G        => 4096,

--- a/firmware/common/pgp2b/hardware/PgpCardG3/rtl/PgpLane.vhd
+++ b/firmware/common/pgp2b/hardware/PgpCardG3/rtl/PgpLane.vhd
@@ -2,7 +2,7 @@
 -- File       : PgpLane.vhd
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2017-10-04
--- Last update: 2018-02-08
+-- Last update: 2018-02-12
 -------------------------------------------------------------------------------
 -- Description: 
 -------------------------------------------------------------------------------
@@ -32,11 +32,10 @@ use unisim.vcomponents.all;
 
 entity PgpLane is
    generic (
-      TPD_G            : time                 := 1 ns;
-      ENABLE_G         : boolean              := true;
-      LANE_G           : natural range 0 to 7 := 0;
-      AXI_ERROR_RESP_G : slv(1 downto 0)      := AXI_RESP_DECERR_C;
-      AXI_BASE_ADDR_G  : slv(31 downto 0)     := (others => '0'));
+      TPD_G           : time                 := 1 ns;
+      ENABLE_G        : boolean              := true;
+      LANE_G          : natural range 0 to 7 := 0;
+      AXI_BASE_ADDR_G : slv(31 downto 0)     := (others => '0'));
    port (
       -- QPLL Clocking
       gtQPllOutRefClk  : in  slv(1 downto 0);
@@ -50,19 +49,19 @@ entity PgpLane is
       pgpRxP           : in  sl;
       pgpRxN           : in  sl;
       -- DMA Interface (dmaClk domain)
-      dmaClk          : in  sl;
-      dmaRst          : in  sl;
-      dmaObMaster     : in  AxiStreamMasterType;
-      dmaObSlave      : out AxiStreamSlaveType;
-      dmaIbMaster     : out AxiStreamMasterType;
-      dmaIbSlave      : in  AxiStreamSlaveType;
+      dmaClk           : in  sl;
+      dmaRst           : in  sl;
+      dmaObMaster      : in  AxiStreamMasterType;
+      dmaObSlave       : out AxiStreamSlaveType;
+      dmaIbMaster      : out AxiStreamMasterType;
+      dmaIbSlave       : in  AxiStreamSlaveType;
       -- AXI-Lite Interface (axilClk domain)
-      axilClk         : in  sl;
-      axilRst         : in  sl;
-      axilReadMaster  : in  AxiLiteReadMasterType;
-      axilReadSlave   : out AxiLiteReadSlaveType;
-      axilWriteMaster : in  AxiLiteWriteMasterType;
-      axilWriteSlave  : out AxiLiteWriteSlaveType);
+      axilClk          : in  sl;
+      axilRst          : in  sl;
+      axilReadMaster   : in  AxiLiteReadMasterType;
+      axilReadSlave    : out AxiLiteReadSlaveType;
+      axilWriteMaster  : in  AxiLiteWriteMasterType;
+      axilWriteSlave   : out AxiLiteWriteSlaveType);
 end PgpLane;
 
 architecture mapping of PgpLane is
@@ -114,7 +113,6 @@ begin
    U_XBAR : entity work.AxiLiteCrossbar
       generic map (
          TPD_G              => TPD_G,
-         DEC_ERROR_RESP_G   => AXI_ERROR_RESP_G,
          NUM_SLAVE_SLOTS_G  => 1,
          NUM_MASTER_SLOTS_G => NUM_AXI_MASTERS_C,
          MASTERS_CONFIG_G   => AXI_CONFIG_C)
@@ -156,9 +154,8 @@ begin
    U_Pgp : entity work.Pgp2bGtp7DrpWrapper
       -- U_Pgp : entity work.Pgp2bGtp7MultiLane
       generic map (
-         TPD_G            => TPD_G,
-         VC_INTERLEAVE_G  => 1,         -- AxiStreamDmaV2 supports interleaving
-         AXI_ERROR_RESP_G => AXI_ERROR_RESP_G)
+         TPD_G           => TPD_G,
+         VC_INTERLEAVE_G => 1)          -- AxiStreamDmaV2 supports interleaving
       port map (
          -- GT Clocking
          gtQPllOutRefClk     => gtQPllOutRefClk,
@@ -210,7 +207,6 @@ begin
    U_PgpMon : entity work.Pgp2bAxi
       generic map (
          TPD_G              => TPD_G,
-         AXI_ERROR_RESP_G   => AXI_ERROR_RESP_G,
          COMMON_TX_CLK_G    => false,
          COMMON_RX_CLK_G    => false,
          WRITE_EN_G         => true,
@@ -241,8 +237,7 @@ begin
    ------------
    U_PgpMiscCtrl : entity work.PgpMiscCtrl
       generic map (
-         TPD_G            => TPD_G,
-         AXI_ERROR_RESP_G => AXI_ERROR_RESP_G)
+         TPD_G => TPD_G)
       port map (
          -- Control/Status  (axilClk domain)
          config          => config,

--- a/firmware/common/pgp2b/hardware/PgpCardG3/rtl/PgpLaneWrapper.vhd
+++ b/firmware/common/pgp2b/hardware/PgpCardG3/rtl/PgpLaneWrapper.vhd
@@ -2,7 +2,7 @@
 -- File       : PgpLaneWrapper.vhd
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2017-10-04
--- Last update: 2018-02-08
+-- Last update: 2018-02-12
 -------------------------------------------------------------------------------
 -- Description: 
 -------------------------------------------------------------------------------
@@ -31,7 +31,6 @@ use unisim.vcomponents.all;
 entity PgpLaneWrapper is
    generic (
       TPD_G            : time             := 1 ns;
-      AXI_ERROR_RESP_G : slv(1 downto 0)  := AXI_RESP_DECERR_C;
       AXI_BASE_ADDR_G  : slv(31 downto 0) := (others => '0'));
    port (
       -- PGP GT Serial Ports
@@ -86,7 +85,6 @@ begin
    U_XBAR : entity work.AxiLiteCrossbar
       generic map (
          TPD_G              => TPD_G,
-         DEC_ERROR_RESP_G   => AXI_ERROR_RESP_G,
          NUM_SLAVE_SLOTS_G  => 1,
          NUM_MASTER_SLOTS_G => NUM_AXI_MASTERS_C,
          MASTERS_CONFIG_G   => AXI_CONFIG_C)
@@ -115,8 +113,7 @@ begin
 
    U_QPLL_WEST : entity work.PgpQpll
       generic map (
-         TPD_G            => TPD_G,
-         AXI_ERROR_RESP_G => AXI_ERROR_RESP_G)
+         TPD_G            => TPD_G)
       port map (
          pgpRefClk      => pgpRefClk,
          qPllRefClk     => qPllRefClk(0),
@@ -129,8 +126,7 @@ begin
 
    U_QPLL_EAST : entity work.PgpQpll
       generic map (
-         TPD_G            => TPD_G,
-         AXI_ERROR_RESP_G => AXI_ERROR_RESP_G)
+         TPD_G            => TPD_G)
       port map (
          pgpRefClk      => pgpRefClk,
          qPllRefClk     => qPllRefClk(1),
@@ -151,8 +147,7 @@ begin
          generic map (
             TPD_G            => TPD_G,
             LANE_G           => (i+WEST_C),
-            AXI_BASE_ADDR_G  => AXI_CONFIG_C(i+WEST_C).baseAddr,
-            AXI_ERROR_RESP_G => AXI_ERROR_RESP_G)
+            AXI_BASE_ADDR_G  => AXI_CONFIG_C(i+WEST_C).baseAddr)
          port map (
             -- QPLL Clocking
             gtQPllOutRefClk  => qPllRefClk(0),
@@ -185,8 +180,7 @@ begin
          generic map (
             TPD_G            => TPD_G,
             LANE_G           => (i+EAST_C),
-            AXI_BASE_ADDR_G  => AXI_CONFIG_C(i+EAST_C).baseAddr,
-            AXI_ERROR_RESP_G => AXI_ERROR_RESP_G)
+            AXI_BASE_ADDR_G  => AXI_CONFIG_C(i+EAST_C).baseAddr)
          port map (
             -- QPLL Clocking
             gtQPllOutRefClk  => qPllRefClk(1),

--- a/firmware/common/pgp2b/hardware/PgpCardG3/rtl/PgpQpll.vhd
+++ b/firmware/common/pgp2b/hardware/PgpCardG3/rtl/PgpQpll.vhd
@@ -2,7 +2,7 @@
 -- File       : PgpQpll.vhd
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2017-10-04
--- Last update: 2017-10-04
+-- Last update: 2018-02-12
 -------------------------------------------------------------------------------
 -- Description: 
 -------------------------------------------------------------------------------
@@ -28,8 +28,7 @@ use unisim.vcomponents.all;
 
 entity PgpQpll is
    generic (
-      TPD_G            : time            := 1 ns;
-      AXI_ERROR_RESP_G : slv(1 downto 0) := AXI_RESP_DECERR_C);
+      TPD_G            : time            := 1 ns);
    port (
       -- QPLL Clocking
       pgpRefClk       : in  sl;
@@ -69,7 +68,6 @@ begin
    U_QPLL : entity work.Gtp7QuadPll
       generic map (
          TPD_G                => TPD_G,
-         AXI_ERROR_RESP_G     => AXI_ERROR_RESP_G,
          -- PLL0 Configured for 1.25 Gbps, 2.5 Gbps, 5.0 Gbps
          PLL0_REFCLK_SEL_G    => "001",
          PLL0_FBDIV_IN_G      => 2,     -- 250 MHz clock reference

--- a/firmware/common/pgp2b/hardware/XilinxKcu1500/rtl/Hardware.vhd
+++ b/firmware/common/pgp2b/hardware/XilinxKcu1500/rtl/Hardware.vhd
@@ -2,7 +2,7 @@
 -- File       : Hardware.vhd
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2017-10-26
--- Last update: 2018-01-08
+-- Last update: 2018-02-12
 -------------------------------------------------------------------------------
 -- Description: Hardware File
 -------------------------------------------------------------------------------
@@ -32,9 +32,8 @@ use unisim.vcomponents.all;
 
 entity Hardware is
    generic (
-      TPD_G            : time             := 1 ns;
-      AXI_ERROR_RESP_G : slv(1 downto 0)  := AXI_RESP_DECERR_C;
-      AXI_BASE_ADDR_G  : slv(31 downto 0) := x"0000_0000");
+      TPD_G           : time             := 1 ns;
+      AXI_BASE_ADDR_G : slv(31 downto 0) := x"0000_0000");
    port (
       ------------------------      
       --  Top Level Interfaces
@@ -81,10 +80,9 @@ begin
    --------------
    U_Pgp : entity work.PgpLaneWrapper
       generic map (
-         TPD_G            => TPD_G,
-         REFCLK_WIDTH_G   => 2,
-         AXI_ERROR_RESP_G => AXI_ERROR_RESP_G,
-         AXI_BASE_ADDR_G  => AXI_BASE_ADDR_G)
+         TPD_G           => TPD_G,
+         REFCLK_WIDTH_G  => 2,
+         AXI_BASE_ADDR_G => AXI_BASE_ADDR_G)
       port map (
          -- QSFP[0] Ports
          qsfp0RefClkP    => qsfp0RefClkP,

--- a/firmware/common/pgp2b/hardware/XilinxKcu1500/rtl/PgpLane.vhd
+++ b/firmware/common/pgp2b/hardware/XilinxKcu1500/rtl/PgpLane.vhd
@@ -2,7 +2,7 @@
 -- File       : PgpLane.vhd
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2017-10-04
--- Last update: 2018-02-08
+-- Last update: 2018-02-12
 -------------------------------------------------------------------------------
 -- Description: 
 -------------------------------------------------------------------------------
@@ -32,10 +32,9 @@ use unisim.vcomponents.all;
 
 entity PgpLane is
    generic (
-      TPD_G            : time                  := 1 ns;
-      LANE_G           : positive range 0 to 7 := 0;
-      AXI_ERROR_RESP_G : slv(1 downto 0)       := AXI_RESP_DECERR_C;
-      AXI_BASE_ADDR_G  : slv(31 downto 0)      := (others => '0'));
+      TPD_G           : time                  := 1 ns;
+      LANE_G          : positive range 0 to 7 := 0;
+      AXI_BASE_ADDR_G : slv(31 downto 0)      := (others => '0'));
    port (
       -- DRP Clock and Reset
       drpClk          : in  sl;
@@ -107,7 +106,6 @@ begin
    U_XBAR : entity work.AxiLiteCrossbar
       generic map (
          TPD_G              => TPD_G,
-         DEC_ERROR_RESP_G   => AXI_ERROR_RESP_G,
          NUM_SLAVE_SLOTS_G  => 1,
          NUM_MASTER_SLOTS_G => NUM_AXI_MASTERS_C,
          MASTERS_CONFIG_G   => AXI_CONFIG_C)
@@ -128,9 +126,8 @@ begin
    -----------
    U_Pgp : entity work.Pgp2bGthUltra
       generic map (
-         TPD_G             => TPD_G,
-         VC_INTERLEAVE_G   => 1,        -- AxiStreamDmaV2 supports interleaving
-         AXIL_ERROR_RESP_G => AXI_ERROR_RESP_G)
+         TPD_G           => TPD_G,
+         VC_INTERLEAVE_G => 1)          -- AxiStreamDmaV2 supports interleaving
       port map (
          -- GT Clocking
          stableClk       => drpClk,
@@ -197,7 +194,6 @@ begin
    U_PgpMon : entity work.Pgp2bAxi
       generic map (
          TPD_G              => TPD_G,
-         AXI_ERROR_RESP_G   => AXI_ERROR_RESP_G,
          COMMON_TX_CLK_G    => false,
          COMMON_RX_CLK_G    => false,
          WRITE_EN_G         => true,
@@ -228,8 +224,7 @@ begin
    ------------
    U_PgpMiscCtrl : entity work.PgpMiscCtrl
       generic map (
-         TPD_G            => TPD_G,
-         AXI_ERROR_RESP_G => AXI_ERROR_RESP_G)
+         TPD_G => TPD_G)
       port map (
          -- Control/Status  (axilClk domain)
          config          => config,

--- a/firmware/common/pgp2b/hardware/XilinxKcu1500/rtl/PgpLaneWrapper.vhd
+++ b/firmware/common/pgp2b/hardware/XilinxKcu1500/rtl/PgpLaneWrapper.vhd
@@ -2,7 +2,7 @@
 -- File       : PgpLaneWrapper.vhd
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2017-10-26
--- Last update: 2018-02-08
+-- Last update: 2018-02-12
 -------------------------------------------------------------------------------
 -- Description: 
 -------------------------------------------------------------------------------
@@ -31,10 +31,9 @@ use unisim.vcomponents.all;
 
 entity PgpLaneWrapper is
    generic (
-      TPD_G            : time             := 1 ns;
-      REFCLK_WIDTH_G   : positive         := 2;
-      AXI_ERROR_RESP_G : slv(1 downto 0)  := AXI_RESP_DECERR_C;
-      AXI_BASE_ADDR_G  : slv(31 downto 0) := (others => '0'));
+      TPD_G           : time             := 1 ns;
+      REFCLK_WIDTH_G  : positive         := 2;
+      AXI_BASE_ADDR_G : slv(31 downto 0) := (others => '0'));
    port (
       -- QSFP[0] Ports
       qsfp0RefClkP    : in  slv(REFCLK_WIDTH_G-1 downto 0);
@@ -174,7 +173,6 @@ begin
    U_XBAR : entity work.AxiLiteCrossbar
       generic map (
          TPD_G              => TPD_G,
-         DEC_ERROR_RESP_G   => AXI_ERROR_RESP_G,
          NUM_SLAVE_SLOTS_G  => 1,
          NUM_MASTER_SLOTS_G => NUM_AXI_MASTERS_C,
          MASTERS_CONFIG_G   => AXI_CONFIG_C)
@@ -197,10 +195,9 @@ begin
 
       U_Lane : entity work.PgpLane
          generic map (
-            TPD_G            => TPD_G,
-            LANE_G           => i,
-            AXI_BASE_ADDR_G  => AXI_CONFIG_C(i).baseAddr,
-            AXI_ERROR_RESP_G => AXI_ERROR_RESP_G)
+            TPD_G           => TPD_G,
+            LANE_G          => i,
+            AXI_BASE_ADDR_G => AXI_CONFIG_C(i).baseAddr)
          port map (
             -- DRP Clock and Reset
             drpClk          => drpClk,

--- a/firmware/common/pgp3/core/PgpLane.vhd
+++ b/firmware/common/pgp3/core/PgpLane.vhd
@@ -2,7 +2,7 @@
 -- File       : PgpLane.vhd
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2017-10-26
--- Last update: 2018-01-10
+-- Last update: 2018-02-12
 -------------------------------------------------------------------------------
 -- Description: 
 -------------------------------------------------------------------------------
@@ -28,11 +28,10 @@ use work.Pgp3Pkg.all;
 
 entity PgpLane is
    generic (
-      TPD_G            : time             := 1 ns;
-      LANE_G           : natural          := 0;
-      NUM_VC_G         : positive         := 4;
-      AXI_ERROR_RESP_G : slv(1 downto 0)  := AXI_RESP_DECERR_C;
-      AXI_BASE_ADDR_G  : slv(31 downto 0) := (others => '0'));
+      TPD_G           : time             := 1 ns;
+      LANE_G          : natural          := 0;
+      NUM_VC_G        : positive         := 4;
+      AXI_BASE_ADDR_G : slv(31 downto 0) := (others => '0'));
    port (
       -- QPLL Interface
       qpllLock        : in  slv(1 downto 0);
@@ -80,11 +79,10 @@ begin
    -----------
    U_Pgp : entity work.Pgp3GthUs
       generic map (
-         TPD_G             => TPD_G,
-         NUM_VC_G          => NUM_VC_G,
-         AXIL_CLK_FREQ_G   => (SYS_CLK_FREQ_C/2.0),
-         AXIL_BASE_ADDR_G  => AXI_BASE_ADDR_G,
-         AXIL_ERROR_RESP_G => AXI_ERROR_RESP_G)
+         TPD_G            => TPD_G,
+         NUM_VC_G         => NUM_VC_G,
+         AXIL_CLK_FREQ_G  => (SYS_CLK_FREQ_C/2.0),
+         AXIL_BASE_ADDR_G => AXI_BASE_ADDR_G)
       port map (
          -- Stable Clock and Reset
          stableClk       => axilClk,
@@ -142,7 +140,7 @@ begin
          pgpTxOut     => pgpTxOut,
          pgpTxMasters => pgpTxMasters,
          pgpTxSlaves  => pgpTxSlaves);
-         
+
    --------------
    -- PGP RX Path
    --------------
@@ -163,5 +161,5 @@ begin
          pgpRxOut     => pgpRxOut,
          pgpRxMasters => pgpRxMasters,
          pgpRxCtrl    => pgpRxCtrl);
-         
+
 end mapping;

--- a/firmware/common/pgp3/core/PgpLaneWrapper.vhd
+++ b/firmware/common/pgp3/core/PgpLaneWrapper.vhd
@@ -2,7 +2,7 @@
 -- File       : PgpLaneWrapper.vhd
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2017-10-26
--- Last update: 2018-02-07
+-- Last update: 2018-02-12
 -------------------------------------------------------------------------------
 -- Description: 
 -------------------------------------------------------------------------------
@@ -32,11 +32,10 @@ use unisim.vcomponents.all;
 
 entity PgpLaneWrapper is
    generic (
-      TPD_G            : time             := 1 ns;
-      REFCLK_WIDTH_G   : positive         := 2;
-      NUM_VC_G         : positive         := 4;
-      AXI_ERROR_RESP_G : slv(1 downto 0)  := AXI_RESP_DECERR_C;
-      AXI_BASE_ADDR_G  : slv(31 downto 0) := (others => '0'));
+      TPD_G           : time             := 1 ns;
+      REFCLK_WIDTH_G  : positive         := 2;
+      NUM_VC_G        : positive         := 4;
+      AXI_BASE_ADDR_G : slv(31 downto 0) := (others => '0'));
    port (
       -- QSFP[0] Ports
       qsfp0RefClkP    : in  slv(REFCLK_WIDTH_G-1 downto 0);
@@ -132,8 +131,7 @@ begin
 
       U_QPLL : entity work.Pgp3GthUsQpll
          generic map (
-            TPD_G             => TPD_G,
-            AXIL_ERROR_RESP_G => AXI_ERROR_RESP_G)
+            TPD_G => TPD_G)
          port map (
             -- Stable Clock and Reset
             stableClk  => axilClk,
@@ -169,7 +167,6 @@ begin
    U_XBAR : entity work.AxiLiteCrossbar
       generic map (
          TPD_G              => TPD_G,
-         DEC_ERROR_RESP_G   => AXI_ERROR_RESP_G,
          NUM_SLAVE_SLOTS_G  => 1,
          NUM_MASTER_SLOTS_G => NUM_AXI_MASTERS_C,
          MASTERS_CONFIG_G   => AXI_CONFIG_C)
@@ -192,11 +189,10 @@ begin
 
       U_Lane : entity work.PgpLane
          generic map (
-            TPD_G            => TPD_G,
-            LANE_G           => i,
-            NUM_VC_G         => NUM_VC_G,
-            AXI_BASE_ADDR_G  => AXI_CONFIG_C(i).baseAddr,
-            AXI_ERROR_RESP_G => AXI_ERROR_RESP_G)
+            TPD_G           => TPD_G,
+            LANE_G          => i,
+            NUM_VC_G        => NUM_VC_G,
+            AXI_BASE_ADDR_G => AXI_CONFIG_C(i).baseAddr)
          port map (
             -- QPLL Interface
             qpllLock        => qpllLock(i),

--- a/firmware/common/pgp3/hardware/AdmPcieKu3/rtl/Hardware.vhd
+++ b/firmware/common/pgp3/hardware/AdmPcieKu3/rtl/Hardware.vhd
@@ -2,7 +2,7 @@
 -- File       : Hardware.vhd
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2017-10-26
--- Last update: 2018-01-08
+-- Last update: 2018-02-12
 -------------------------------------------------------------------------------
 -- Description: Hardware File
 -------------------------------------------------------------------------------
@@ -32,9 +32,8 @@ use unisim.vcomponents.all;
 
 entity Hardware is
    generic (
-      TPD_G            : time             := 1 ns;
-      AXI_ERROR_RESP_G : slv(1 downto 0)  := AXI_RESP_DECERR_C;
-      AXI_BASE_ADDR_G  : slv(31 downto 0) := x"0000_0000");
+      TPD_G           : time             := 1 ns;
+      AXI_BASE_ADDR_G : slv(31 downto 0) := x"0000_0000");
    port (
       ------------------------      
       --  Top Level Interfaces
@@ -81,11 +80,10 @@ begin
    --------------
    U_Pgp : entity work.PgpLaneWrapper
       generic map (
-         TPD_G            => TPD_G,
-         REFCLK_WIDTH_G   => 1,
-         NUM_VC_G         => 4,    
-         AXI_ERROR_RESP_G => AXI_ERROR_RESP_G,
-         AXI_BASE_ADDR_G  => AXI_BASE_ADDR_G)
+         TPD_G           => TPD_G,
+         REFCLK_WIDTH_G  => 1,
+         NUM_VC_G        => 4,
+         AXI_BASE_ADDR_G => AXI_BASE_ADDR_G)
       port map (
          -- QSFP[0] Ports
          qsfp0RefClkP(0) => qsfp0RefClkP,

--- a/firmware/common/pgp3/hardware/XilinxKcu1500/core/Hardware.vhd
+++ b/firmware/common/pgp3/hardware/XilinxKcu1500/core/Hardware.vhd
@@ -2,7 +2,7 @@
 -- File       : Hardware.vhd
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2017-10-26
--- Last update: 2018-01-08
+-- Last update: 2018-02-12
 -------------------------------------------------------------------------------
 -- Description: Hardware File
 -------------------------------------------------------------------------------
@@ -32,9 +32,8 @@ use unisim.vcomponents.all;
 
 entity Hardware is
    generic (
-      TPD_G            : time             := 1 ns;
-      AXI_ERROR_RESP_G : slv(1 downto 0)  := AXI_RESP_DECERR_C;
-      AXI_BASE_ADDR_G  : slv(31 downto 0) := x"0000_0000");
+      TPD_G           : time             := 1 ns;
+      AXI_BASE_ADDR_G : slv(31 downto 0) := x"0000_0000");
    port (
       ------------------------      
       --  Top Level Interfaces
@@ -81,11 +80,10 @@ begin
    --------------
    U_Pgp : entity work.PgpLaneWrapper
       generic map (
-         TPD_G            => TPD_G,
-         REFCLK_WIDTH_G   => 2,
-         NUM_VC_G         => 16,        
-         AXI_ERROR_RESP_G => AXI_ERROR_RESP_G,
-         AXI_BASE_ADDR_G  => AXI_BASE_ADDR_G)
+         TPD_G           => TPD_G,
+         REFCLK_WIDTH_G  => 2,
+         NUM_VC_G        => 16,
+         AXI_BASE_ADDR_G => AXI_BASE_ADDR_G)
       port map (
          -- QSFP[0] Ports
          qsfp0RefClkP    => qsfp0RefClkP,

--- a/firmware/targets/AdmPcieKu3Pgp2b/hdl/AdmPcieKu3Pgp2b.vhd
+++ b/firmware/targets/AdmPcieKu3Pgp2b/hdl/AdmPcieKu3Pgp2b.vhd
@@ -2,7 +2,7 @@
 -- File       : AdmPcieKu3Pgp2b.vhd
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2017-10-24
--- Last update: 2018-02-07
+-- Last update: 2018-02-12
 -------------------------------------------------------------------------------
 -- Description: 
 -------------------------------------------------------------------------------
@@ -148,7 +148,6 @@ begin
    U_Hardware : entity work.Hardware
       generic map (
          TPD_G            => TPD_G,
-         AXI_ERROR_RESP_G => BAR0_ERROR_RESP_C,
          AXI_BASE_ADDR_G  => BAR0_BASE_ADDR_C)
       port map (
          ------------------------      

--- a/firmware/targets/AdmPcieKu3Pgp3/hdl/AdmPcieKu3Pgp3.vhd
+++ b/firmware/targets/AdmPcieKu3Pgp3/hdl/AdmPcieKu3Pgp3.vhd
@@ -2,7 +2,7 @@
 -- File       : AdmPcieKu3Pgp3.vhd
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2017-10-24
--- Last update: 2018-02-07
+-- Last update: 2018-02-12
 -------------------------------------------------------------------------------
 -- Description: 
 -------------------------------------------------------------------------------
@@ -147,9 +147,8 @@ begin
 
    U_Hardware : entity work.Hardware
       generic map (
-         TPD_G            => TPD_G,
-         AXI_ERROR_RESP_G => BAR0_ERROR_RESP_C,
-         AXI_BASE_ADDR_G  => BAR0_BASE_ADDR_C)
+         TPD_G           => TPD_G,
+         AXI_BASE_ADDR_G => BAR0_BASE_ADDR_C)
       port map (
          ------------------------      
          --  Top Level Interfaces

--- a/firmware/targets/AdmPcieKu3PrbsTester/hdl/AdmPcieKu3PrbsTester.vhd
+++ b/firmware/targets/AdmPcieKu3PrbsTester/hdl/AdmPcieKu3PrbsTester.vhd
@@ -2,7 +2,7 @@
 -- File       : AdmPcieKu3PrbsTester.vhd
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2017-10-24
--- Last update: 2018-02-08
+-- Last update: 2018-02-12
 -------------------------------------------------------------------------------
 -- Description: 
 -------------------------------------------------------------------------------
@@ -179,7 +179,6 @@ begin
       generic map (
          TPD_G            => TPD_G,
          NUM_VC_G         => 4,
-         AXI_ERROR_RESP_G => BAR0_ERROR_RESP_C,
          AXI_BASE_ADDR_G  => BAR0_BASE_ADDR_C)
       port map (
          -- AXI-Lite Interface

--- a/firmware/targets/PgpCardG3Pgp2b/hdl/PgpCardG3Pgp2b.vhd
+++ b/firmware/targets/PgpCardG3Pgp2b/hdl/PgpCardG3Pgp2b.vhd
@@ -2,7 +2,7 @@
 -- File       : PgpCardG3Pgp2b.vhd
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2017-09-28
--- Last update: 2018-02-08
+-- Last update: 2018-02-12
 -------------------------------------------------------------------------------
 -- Description: 
 -------------------------------------------------------------------------------
@@ -152,7 +152,6 @@ begin
    U_Hardware : entity work.Hardware
       generic map (
          TPD_G            => TPD_G,
-         AXI_ERROR_RESP_G => BAR0_ERROR_RESP_C,
          AXI_BASE_ADDR_G  => BAR0_BASE_ADDR_C)
       port map (
          ------------------------      

--- a/firmware/targets/PgpCardG3PrbsTester/hdl/PgpCardG3PrbsTester.vhd
+++ b/firmware/targets/PgpCardG3PrbsTester/hdl/PgpCardG3PrbsTester.vhd
@@ -2,7 +2,7 @@
 -- File       : PgpCardG3PrbsTester.vhd
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2017-09-28
--- Last update: 2018-02-08
+-- Last update: 2018-02-12
 -------------------------------------------------------------------------------
 -- Description: 
 -------------------------------------------------------------------------------
@@ -178,7 +178,6 @@ begin
       generic map (
          TPD_G            => TPD_G,
          NUM_VC_G         => 1,
-         AXI_ERROR_RESP_G => BAR0_ERROR_RESP_C,
          AXI_BASE_ADDR_G  => BAR0_BASE_ADDR_C)
       port map (
          -- AXI-Lite Interface

--- a/firmware/targets/XilinxKcu1500Pgp2b/hdl/XilinxKcu1500Pgp2b.vhd
+++ b/firmware/targets/XilinxKcu1500Pgp2b/hdl/XilinxKcu1500Pgp2b.vhd
@@ -2,7 +2,7 @@
 -- File       : XilinxKcu1500Pgp2b.vhd
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2017-10-24
--- Last update: 2018-02-07
+-- Last update: 2018-02-12
 -------------------------------------------------------------------------------
 -- Description: 
 -------------------------------------------------------------------------------
@@ -206,7 +206,6 @@ begin
    U_Hardware : entity work.Hardware
       generic map (
          TPD_G            => TPD_G,
-         AXI_ERROR_RESP_G => BAR0_ERROR_RESP_C,
          AXI_BASE_ADDR_G  => BAR0_BASE_ADDR_C)
       port map (
          ------------------------      

--- a/firmware/targets/XilinxKcu1500Pgp3/hdl/XilinxKcu1500Pgp3.vhd
+++ b/firmware/targets/XilinxKcu1500Pgp3/hdl/XilinxKcu1500Pgp3.vhd
@@ -2,7 +2,7 @@
 -- File       : XilinxKcu1500Pgp3.vhd
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2017-10-24
--- Last update: 2018-02-07
+-- Last update: 2018-02-12
 -------------------------------------------------------------------------------
 -- Description: 
 -------------------------------------------------------------------------------
@@ -206,7 +206,6 @@ begin
    U_Hardware : entity work.Hardware
       generic map (
          TPD_G            => TPD_G,
-         AXI_ERROR_RESP_G => BAR0_ERROR_RESP_C,
          AXI_BASE_ADDR_G  => BAR0_BASE_ADDR_C)
       port map (
          ------------------------      

--- a/firmware/targets/XilinxKcu1500PrbsTester/hdl/XilinxKcu1500PrbsTester.vhd
+++ b/firmware/targets/XilinxKcu1500PrbsTester/hdl/XilinxKcu1500PrbsTester.vhd
@@ -2,7 +2,7 @@
 -- File       : XilinxKcu1500PrbsTester.vhd
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2017-10-24
--- Last update: 2018-02-08
+-- Last update: 2018-02-12
 -------------------------------------------------------------------------------
 -- Description: 
 -------------------------------------------------------------------------------
@@ -237,7 +237,6 @@ begin
       generic map (
          TPD_G            => TPD_G,
          NUM_VC_G         => 4,
-         AXI_ERROR_RESP_G => BAR0_ERROR_RESP_C,
          AXI_BASE_ADDR_G  => BAR0_BASE_ADDR_C)
       port map (
          -- AXI-Lite Interface

--- a/firmware/targets/XilinxVcu1525PrbsTester/hdl/Application.vhd
+++ b/firmware/targets/XilinxVcu1525PrbsTester/hdl/Application.vhd
@@ -2,7 +2,7 @@
 -- File       : Application.vhd
 -- Company    : SLAC National Accelerator Laboratory
 -- Created    : 2018-01-30
--- Last update: 2018-02-02
+-- Last update: 2018-02-12
 -------------------------------------------------------------------------------
 -- Description: Application File
 -------------------------------------------------------------------------------
@@ -97,7 +97,6 @@ architecture mapping of Application is
    -- Defined module generics as constants (in case partial reconfiguration build)
    constant TPD_G            : time             := 1 ns;
    constant AXI_BASE_ADDR_G  : slv(31 downto 0) := BAR0_BASE_ADDR_C;
-   constant AXI_ERROR_RESP_G : slv(1 downto 0)  := BAR0_ERROR_RESP_C;
 
    constant NUM_AXI_MASTERS_C : natural := 2;
 
@@ -147,7 +146,6 @@ begin
    U_XBAR : entity work.AxiLiteCrossbar
       generic map (
          TPD_G              => TPD_G,
-         DEC_ERROR_RESP_G   => AXI_ERROR_RESP_G,
          NUM_SLAVE_SLOTS_G  => 1,
          NUM_MASTER_SLOTS_G => NUM_AXI_MASTERS_C,
          MASTERS_CONFIG_G   => AXI_CONFIG_C)
@@ -187,7 +185,6 @@ begin
       generic map (
          TPD_G            => TPD_G,
          NUM_VC_G         => 4,
-         AXI_ERROR_RESP_G => BAR0_ERROR_RESP_C,
          AXI_BASE_ADDR_G  => AXI_CONFIG_C(1).baseAddr)
       port map (
          -- AXI-Lite Interface


### PR DESCRIPTION
Updated for compatibility with SURF v1.7.0 - slaclab/surf#147.
 * Removed all AXI_ERROR_RESP_G generics
 * Removed all AxiLiteEmpty instances